### PR TITLE
Switch libnuma checks to HAVE_ENABLE_NUMA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,15 +58,10 @@ if (NUMA_FOUND)
   if (WITH_NUMA)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NUMA_CFLAGS}")
 
-    list(APPEND CMAKE_REQUIRED_LIBRARIES ${NUMA_LDFLAGS}) # CMP0075, requires CMake 3.12
-    check_symbol_exists(numa_node_to_cpus     "numa.h" HAVE_NUMA_NODE_TO_CPUS)
-    check_symbol_exists(numa_allocate_cpumask "numa.h" HAVE_NUMA_ALLOCATE_CPUMASK)
-    list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES ${NUMA_LDFLAGS})
-
     set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES}, numactl-libs")
     list(APPEND CPACK_DEBIAN_PACKAGE_DEPENDS "libnuma1")
 
-    set(HAVE_NUMA_H 1)
+    set(HAVE_ENABLE_NUMA 1)
   endif()
 else()
   message(STATUS "libnuma not found")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,7 @@ if (IBVERBS AND IBV_GET_DEVICE_LIST AND WITH_VERBS)
   target_link_libraries(xdd-lib ibverbs)
 endif()
 
-if (NUMA_FOUND AND HAVE_NUMA_NODE_TO_CPUS AND HAVE_NUMA_ALLOCATE_CPUMASK AND WITH_NUMA)
+if (NUMA_FOUND AND WITH_NUMA)
   target_link_libraries(xdd-lib ${NUMA_LDFLAGS})
 endif()
 

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -18,7 +18,7 @@
 #include "xint.h"
 #include "parse.h"
 
-#if HAVE_NUMA_H
+#if HAVE_ENABLE_NUMA
 #include <numa.h>
 #endif
 
@@ -382,7 +382,7 @@ void xdd_set_target_cpu_mask(target_data_t *tdp, char *numa_nodes)
 	int node_list_offset = 0;
 	tdp->numa_node_list[node_list_offset] = '\0';
 
-#if HAVE_NUMA_NODE_TO_CPUS && HAVE_NUMA_ALLOCATE_CPUMASK
+#if HAVE_ENABLE_NUMA
 	int numa_node_no = -1;
 	struct bitmask* numa_mask = NULL;
 	char *cmdline = strdup(numa_nodes);
@@ -410,11 +410,11 @@ void xdd_set_target_cpu_mask(target_data_t *tdp, char *numa_nodes)
 		free(cmdline);
 		numa_free_cpumask(numa_mask);
 	}
-#else /* HAVE_NUMA_NODE_TO_CPUS && HAVE_NUMA_ALLOCATE_CPUMASK */
+#else /* HAVE_ENABLE_NUMA */
 	sched_getaffinity(getpid(),
 					  sizeof(tdp->cpumask),
 					  &tdp->cpumask);
-#endif /* HAVE_NUMA_NODE_TO_CPUS && HAVE_NUMA_ALLOCATE_CPUMASK */
+#endif /* HAVE_ENABLE_NUMA */
 } /* end of xdd_set_target_cpu_mask() */
 #endif /* HAVE_CPU_SET_T */
 

--- a/src/client/parse_func.c
+++ b/src/client/parse_func.c
@@ -20,7 +20,7 @@
 #include "parse.h"
 #include <ctype.h>
 
-#if HAVE_NUMA_H
+#if HAVE_ENABLE_NUMA
 #include <numa.h>
 #endif
 
@@ -1169,7 +1169,7 @@ xddfunc_endtoend(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 		    		tdp->td_e2ep->e2e_address_table[tdp->td_e2ep->e2e_address_table_next_entry].port_count = 0;
 				}
 
-#if HAVE_CPU_SET_T && HAVE_NUMA_NODE_TO_CPUS && HAVE_NUMA_ALLOCATE_CPUMASK
+#if HAVE_CPU_SET_T && HAVE_ENABLE_NUMA
 				if (numa_node && -1 != numa_available()) {
 		    		int i;
 		    		struct bitmask* numa_mask = numa_allocate_cpumask();
@@ -1220,7 +1220,7 @@ xddfunc_endtoend(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 						} else {
 			    			tdp->td_e2ep->e2e_address_table[tdp->td_e2ep->e2e_address_table_next_entry].port_count = 0;
 						}
-#if HAVE_CPU_SET_T && HAVE_NUMA_NODE_TO_CPUS && HAVE_NUMA_ALLOCATE_CPUMASK
+#if HAVE_CPU_SET_T && HAVE_ENABLE_NUMA
 						if (numa_node && -1 != numa_available()) {
 			    			int i;
 			    			struct bitmask* numa_mask = numa_allocate_cpumask();

--- a/src/compat/config.h.in
+++ b/src/compat/config.h.in
@@ -82,9 +82,6 @@
 /* Define to 1 if you have the <utmpx.h> header file. */
 #cmakedefine01 HAVE_UTMPX_H
 
-/* Define to 1 if you have the <numa.h> header file. */
-#cmakedefine01 HAVE_NUMA_H
-
 /* Define to 1 if you have the <sched.h> header file. */
 #cmakedefine01 HAVE_SCHED_H
 
@@ -115,12 +112,6 @@
 
 /* Define to 1 if you have the `nanosleep' function. */
 #cmakedefine01 HAVE_NANOSLEEP
-
-/* Define to 1 if you have the `numa_node_to_cpus' function. */
-#cmakedefine01 HAVE_NUMA_NODE_TO_CPUS
-
-/* Define to 1 if you have the `numa_allocate_cpumask' function. */
-#cmakedefine01 HAVE_NUMA_ALLOCATE_CPUMASK
 
 /* Define to 1 if you have the `posix_memalign' function. */
 #cmakedefine01 HAVE_POSIX_MEMALIGN
@@ -173,6 +164,9 @@
 
 /* Define to `unsigned int' if <sys/types.h> does not define. */
 #cmakedefine size_t unsigned int
+
+/* Define to 1 if you wish to enable numactl support */
+#cmakedefine01 HAVE_ENABLE_NUMA
 
 /* Define to 1 if you wish to enable Infiniband support */
 #cmakedefine01 HAVE_ENABLE_IB


### PR DESCRIPTION
just because libnuma was found does not mean it should be enabled
configure with `-DWITH_NUMA=On`
  - sets `HAVE_ENABLE_NUMA`
  - setting `-DHAVE_ENABLE_NUMA=On` directly is not recommend

should not have to check for individual symbols `numa_node_to_cpus` and `numa_allocate_cpumask`
no longer setting/checking for `HAVE_NUMA_H`