### PR TITLE
Only print thread bindings in debug mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,10 @@ include_directories(
   "${CMAKE_CURRENT_BINARY_DIR}/compat" # oonfig.h
 )
 
+# Modified answer by ixSci
+# https://stackoverflow.com/a/72330784
+add_compile_definitions(DEBUG=$<CONFIG:Debug>)
+
 # copied from configure.ac
 # removed __INTEL__ and _FILE_OFFSET_BITS=64
 add_compile_definitions(LINUX)

--- a/src/base/worker_thread_init.c
+++ b/src/base/worker_thread_init.c
@@ -29,14 +29,14 @@ xdd_worker_thread_init(worker_data_t *wdp) {
     char			tmpname[XDD_BARRIER_MAX_NAME_LENGTH];	// Used to create unique names for the barriers
 	unsigned char	*bufp;		// Generic Buffer pointer
 
-#if HAVE_CPU_SET_T && HAVE_PTHREAD_ATTR_SETAFFINITY_NP
+#if DEBUG && HAVE_CPU_SET_T && HAVE_PTHREAD_ATTR_SETAFFINITY_NP
     // BWS Print the cpuset
     int i;
     cpu_set_t cpuset;
     CPU_ZERO(&cpuset);
     pthread_getaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
     printf("Thread %ld bound to NUMA node", (long int) pthread_self());
-    for (i = 0; i< 48; i++)
+    for (i = 0; i < CPU_SETSIZE; i++)
         if (CPU_ISSET(i, &cpuset))
             printf(" %d", i);
     printf("\n");


### PR DESCRIPTION
add -DDEBUG=1 when CMAKE_BUILD_TYPE is debug
use CPU_SETSIZE instead of 48

Fixes #13