### PR TITLE
Removing chatting CMake build disabling checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,44 +24,44 @@ include(CheckIncludeFiles)
 include(CheckSymbolExists)
 
 # find libibverbs
-find_library(IBVERBS ibverbs)
-if (IBVERBS)
-  message(STATUS "libibverbs: ${IBVERBS}")
-  check_include_files(infiniband/verbs.h HAVE_INFINIBAND_VERBS_H)
-
-  list(APPEND CMAKE_REQUIRED_LIBRARIES -libverbs) # CMP0075, requires CMake 3.12
-  check_symbol_exists(ibv_get_device_list "infiniband/verbs.h" IBV_GET_DEVICE_LIST)
-  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES -libverbs)
-  if (IBV_GET_DEVICE_LIST)
-    option(WITH_VERBS "Build with verbs" ON)
-    if (WITH_VERBS)
+option(WITH_VERBS "Build with verbs" ON)
+if (WITH_VERBS)
+  find_library(IBVERBS ibverbs)
+  if (IBVERBS)
+    message(STATUS "libibverbs: ${IBVERBS}")
+    check_include_files(infiniband/verbs.h HAVE_INFINIBAND_VERBS_H)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES -libverbs) # CMP0075, requires CMake 3.12
+    check_symbol_exists(ibv_get_device_list "infiniband/verbs.h" IBV_GET_DEVICE_LIST)
+    list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES -libverbs)
+    if (IBV_GET_DEVICE_LIST)
       set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES}, libibverbs")
       list(APPEND CPACK_DEBIAN_PACKAGE_DEPENDS "libibverbs1")
-
       set(HAVE_ENABLE_IB 1)
+    else()
+      message(STATUS "libibverbs found but missing symbol ibv_get_device_list")
     endif()
+  else()
+    message(STATUS "libibverbs not found.")
   endif()
-else()
-  message(STATUS "libibverbs not found")
 endif()
 
 # libnuma is optional
-pkg_search_module(NUMA numa)
-if (NUMA_FOUND)
-  message(STATUS "libnuma CFLAGS:  ${NUMA_CFLAGS}")
-  message(STATUS "libnuma LDFLAGS: ${NUMA_LDFLAGS}")
+option(WITH_NUMA "Build with libnuma" ON)
+if (WITH_NUMA)
+  pkg_search_module(NUMA numa)
+  if (NUMA_FOUND)
+    message(STATUS "libnuma CFLAGS:  ${NUMA_CFLAGS}")
+    message(STATUS "libnuma LDFLAGS: ${NUMA_LDFLAGS}")
 
-  option(WITH_NUMA "Build with libnuma" ON)
-  if (WITH_NUMA)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NUMA_CFLAGS}")
 
     set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES}, numactl-libs")
     list(APPEND CPACK_DEBIAN_PACKAGE_DEPENDS "libnuma1")
 
     set(HAVE_ENABLE_NUMA 1)
+  else()
+    message(STATUS "libnuma not found")
   endif()
-else()
-  message(STATUS "libnuma not found")
 endif()
 
 # optionally build for flamegraph analysis

--- a/src/client/parse_func.c
+++ b/src/client/parse_func.c
@@ -2337,7 +2337,7 @@ xddfunc_noproclock(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags
 		xgp->global_options |= GO_NOPROCLOCK;
     return(1);
 }
-#if HAVE_CPU_SET_T
+#if HAVE_ENABLE_NUMA
 /*----------------------------------------------------------------------------*/
 // Specify the NUMA domain to pin worker threads of a particular target
 // Arguments: -numactl [target #] #[,#]*
@@ -2374,7 +2374,7 @@ xddfunc_numactl(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 		return(2);
 	}
 }
-#endif /* HAVE_CPU_SET_T */
+#endif /* HAVE_ENABLE_NUMA */
 /*----------------------------------------------------------------------------*/
 // Specify the number of requests to run
 // Arguments: -numreqs [target #] #

--- a/src/client/parse_table.c
+++ b/src/client/parse_table.c
@@ -351,7 +351,7 @@ xdd_func_t  xdd_func[] = {
             {"    Will set not lock process into memory\n",
             0,0,0,0},
 			0},
-#if HAVE_CPU_SET_T
+#if HAVE_ENABLE_NUMA
     {"numactl", "numa",
             xddfunc_numactl,
             1,


### PR DESCRIPTION
When using:
-DWITH_NUMA=OFF
-DWITH_VERBS=OFF

We can avoid issuing out statments of checking for anything with those when the cmake command is issues. This just helps to clear up clutter in the output.