### PR TITLE
Fix common.sh Weirdness

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-configure_file(common.sh common.sh)
+configure_file(common.sh common.sh COPYONLY)
 
 # original tests depended on xdd being installed
 option(TEST_INSTALLED "Use installed xdd for tests" ON)
@@ -15,7 +15,7 @@ if (NOT Time_EXECUTABLE)
   message(CHECK_FAIL "not found: ctest will skip tests test_xdd_{passdelay/startdelay}")
 else()
   message(CHECK_PASS "found")
-endif() 
+endif()
 
 # configurable output directory
 set(TESTDIR "${CMAKE_BINARY_DIR}/test-dir" CACHE PATH "Where to place test files")

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -11,9 +11,6 @@
 #  - generates correct test data files
 #  - generates correct test file names
 #
-#
-# curly braces with global variables
-# break in this file for some reason
 
 TESTNAME=$(basename "$0" | cut -f 1 -d .)
 common_next_file=""
@@ -23,19 +20,19 @@ common_next_file=""
 #
 initialize_test() {
     # Ensure that the test config has been sourced
-    if [[ -z "$XDDTEST_LOG_DIR" ]]; then
+    if [[ -z "${XDDTEST_LOG_DIR}" ]]; then
         echo "No properly sourced test_config during initialization. Missing log file path."
         finalize_test 2
     fi
 
     # Create directories associated with local tests
-    if ! mkdir -p "$XDDTEST_LOCAL_MOUNT/$TESTNAME" ; then
-        echo "Unable to create $XDDTEST_LOCAL_MOUNT/$TESTNAME"
+    if ! mkdir -p "${XDDTEST_LOCAL_MOUNT}/${TESTNAME}" ; then
+        echo "Unable to create ${XDDTEST_LOCAL_MOUNT}/${TESTNAME}"
         finalize_test 2
     fi
 
     # Create the log directory
-    mkdir -p "$XDDTEST_LOG_DIR"
+    mkdir -p "${XDDTEST_LOG_DIR}"
 
     # Initialize the uid for data files
     common_next_file="0"
@@ -70,7 +67,7 @@ finalize_test() {
 # Get logfile for this test to store additional test output in if desired
 #
 get_log_file() {
-    echo "$XDDTEST_LOG_DIR/$TESTNAME.log"
+    echo "${XDDTEST_LOG_DIR}/${TESTNAME}.log"
 }
 
 #
@@ -78,7 +75,7 @@ get_log_file() {
 #
 generate_local_filename() {
     local varname="$1"
-    local name="$XDDTEST_LOCAL_MOUNT/$TESTNAME/file${common_next_file}.tdt"
+    local name="${XDDTEST_LOCAL_MOUNT}/${TESTNAME}/file${common_next_file}.tdt"
     eval "${varname}=${name}"
     common_next_file="$((common_next_file + 1))"
     return 0
@@ -126,7 +123,7 @@ generate_local_file() {
 cleanup_test_data() {
     # Remove files associated with local tests
     # shellcheck disable=SC2115
-    rm -r "$XDDTEST_LOCAL_MOUNT/$TESTNAME"
+    rm -r "${XDDTEST_LOCAL_MOUNT}/${TESTNAME}"
 }
 
 #
@@ -134,7 +131,7 @@ cleanup_test_data() {
 #
 fail() {
     local message="$1"
-    printf "%-20s\t%10s: %s\n" "$TESTNAME" "FAIL" "$message"
+    printf "%-20s\t%10s: %s\n" "${TESTNAME}" "FAIL" "${message}"
 }
 
 #
@@ -149,5 +146,5 @@ pass() {
 #
 skip() {
     local message="$1"
-    printf "%-20s\t%10s: %s\n" "$TESTNAME" "SKIPPED" "$message"
+    printf "%-20s\t%10s: %s\n" "${TESTNAME}" "SKIPPED" "${message}"
 }

--- a/tests/debug/test_xdd_debug_init.sh
+++ b/tests/debug/test_xdd_debug_init.sh
@@ -16,7 +16,7 @@ initialize_test
 
 ("${XDDTEST_XDD_EXE}" -op write -reqsize 128 -numreqs 1 -targets 1 /dev/null -verbose -debug INIT 2>&1 | grep "bound to NUMA node") || finalize_test 1 "XDD output is missing NUMA node pinning info"
 
-("${XDDTEST_XDD_EXE}" -op write -reqsize 128 -numreqs 1 -targets 1 /dev/null -verbose 2>&1 | grep "bound to NUMA node") || finalize_test 1 "XDD output should not have NUMA node pinning info because -debug INIT was not used"
+("${XDDTEST_XDD_EXE}" -op write -reqsize 128 -numreqs 1 -targets 1 /dev/null -verbose 2>&1 | grep "bound to NUMA node") && finalize_test 1 "XDD output should not have NUMA node pinning info because -debug INIT was not used"
 
 # test passed
 finalize_test 0

--- a/tests/functional/test_xdd_syncwrite.sh
+++ b/tests/functional/test_xdd_syncwrite.sh
@@ -28,7 +28,7 @@ num_passes=10
 xdd_cmd="${XDDTEST_XDD_EXE} -target ${test_file} -op write -numreqs 10 -passes $num_passes -syncwrite"
 # shellcheck disable=SC2086
 sys_call=$(2>&1 strace -cfq -e trace=fdatasync ${xdd_cmd} | grep "fdatasync")
-sync_num=$(echo "${sys_call}" | cut -f 4 -d ' ')
+sync_num=$(echo "${sys_call}" | awk '{ print $4 }')
 
 # Verify output
 if [[ "${sync_num}" -eq "${num_passes}" ]]; then
@@ -36,5 +36,5 @@ if [[ "${sync_num}" -eq "${num_passes}" ]]; then
   finalize_test 0
 else
   # test failed
-  finalize_test 1 "fdatasync calls $sync_num != $num_passes when using -passes $num_passes -syncwrite"
+  finalize_test 1 "fdatasync calls ${sync_num} != ${num_passes} when using -passes ${num_passes} -syncwrite"
 fi


### PR DESCRIPTION
tests/CMakeLists.txt was calling configure_file without a copy method, and it was copying common.sh weirdly
also fixed a few other issues that were prevented by this issue/missed in the previous shellcheck commit

updated test_xdd_reopen.sh
- grep for the words, not just the strings
- ignoring syscall count mismatches for now (see #19)