### PR TITLE
Fixed issue with dryrun option that caused hanging

### DIFF
--- a/src/client/results_manager.c
+++ b/src/client/results_manager.c
@@ -65,6 +65,10 @@ xdd_results_manager(void *data) {
 	xdd_init_barrier_occupant(&barrier_occupant, "RESULTS_MANAGER", (XDD_OCCUPANT_TYPE_SUPPORT), NULL);
 	xdd_barrier(&planp->main_general_init_barrier,&barrier_occupant,0);
 
+	if (xgp->global_options & GO_DRYRUN) {
+		return(0);
+	}
+
 	// This is the loop that runs continuously throughout the xdd run
 	while (1) {
 		// This barrier will release all the targets at the start of a pass so they all start at the same time

--- a/src/client/xdd.c
+++ b/src/client/xdd.c
@@ -67,6 +67,7 @@ DFLOW("\n----------------------All targets should start now---------------------
 	// At this point all the Target threads are running and we will enter the final_barrier 
 	// waiting for them to finish or exit if this is just a dry run
 	if (xgp->global_options & GO_DRYRUN) {
+		fprintf(xgp->output, "Run has ended due to dry run option being enabled. \n");
 		// Cleanup the semaphores and barriers 
 		xdd_destroy_all_barriers(planp);
 		return(XDD_RETURN_VALUE_SUCCESS);

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(FUNCTIONAL
     test_xdd_createnewfiles2.sh
+    test_xdd_dryrun.sh
     test_xdd_heartbeat_byte.sh
     test_xdd_heartbeat_elapsed.sh
     test_xdd_heartbeat_lf.sh

--- a/tests/functional/test_xdd_dryrun.sh
+++ b/tests/functional/test_xdd_dryrun.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Acceptance test for XDD.
+#
+# Validate the functionality of the -dryrun option to ensure it works as intended.
+#
+# Description - passes the dry run option to a simple xdd command 
+#
+# Source the test configuration environment
+#
+source ../test_config
+source ../common.sh
+
+# Perform pre-test
+initialize_test
+test_dir="${XDDTEST_LOCAL_MOUNT}/${TESTNAME}"
+log_file="$(get_log_file)"
+
+# ReqSize 4096, Bytes 1MB, Targets 1, QueueDepth 4, Passes 1
+data_file="${test_dir}/test"
+
+# write a file
+"${XDDTEST_XDD_EXE}" -op write -reqsize 4096 -mbytes 1 -targets 1 "${data_file}" -qd 4 -passes 1 -datapattern random
+
+# now run dryrun
+sleep_seconds=2
+"${XDDTEST_XDD_EXE}" -op read  -reqsize 1 -targets 1 "${data_file}" -dryrun &
+pid=$!
+
+# sleep for 2 seconds before checking if XDD process is still running
+(
+echo "xdd started, pid=${pid}"
+echo "sleep ${sleep_seconds}" 
+) > "${log_file}"
+sleep "${sleep_seconds}"
+
+if pkill "${pid}" ; then
+  # test failed
+  echo "Had to kill ${pid}." >> "${log_file}"
+  finalize_test 1 "Requested -dryrun option, but XDD process was still running after ${sleep_seconds}, something is causing it to hang"
+else 
+  # test passed
+  finalize_test 0
+fi


### PR DESCRIPTION
Fixed an issue with the dryrun option that would cause xdd to hang whenever the option was enabled. The issue lied in src/client/results_manager.c, as it was stuck waiting in a barrier for the other threads to also enter the barrier, which they would never do as the other threads have already exited.

Also added a test to ensure that the dryrun option functions correctly.