### PR TITLE
make shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
     - name: Install ShellCheck
       run: sudo apt -y install shellcheck
     - name: Run ShellCheck
-      run: shellcheck -s bash -e SC1091 $(find -name "*.sh" | sort)
+      run: contrib/CI/shellcheck.sh .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,9 @@ add_subdirectory(src)
 enable_testing()
 add_subdirectory(tests)
 
+# set up extra files
+add_subdirectory(contrib)
+
 # optionally build docs
 find_package(Doxygen COMPONENTS dot)
 if (DOXYGEN_FOUND)

--- a/contrib/CI/CMakeLists.txt
+++ b/contrib/CI/CMakeLists.txt
@@ -1,0 +1,7 @@
+# enable make shellcheck
+find_program(SHELLCHECK shellcheck)
+if (SHELLCHECK)
+  message(STATUS "Shellcheck found. Run 'make shellcheck' to check for shell script issues")
+  configure_file(shellcheck.sh shellcheck.sh COPYONLY)
+  add_custom_target(shellcheck "${CMAKE_CURRENT_BINARY_DIR}/shellcheck.sh" "${CMAKE_BINARY_DIR}")
+endif()

--- a/contrib/CI/shellcheck.sh
+++ b/contrib/CI/shellcheck.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+# shellcheck disable=SC2046
+shellcheck -s bash -e SC1091 $(find "$@" -name "*.sh" | sort)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(CI)

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -82,42 +82,6 @@ generate_local_filename() {
 }
 
 #
-# Create local test file of size n, outputs filename
-#
-generate_local_file() {
-    local varname="$1"
-    local size="$2"
-
-    if [[ -z "${size}" ]]; then
-        echo "No test file data size specified."
-        finalize_test 2
-    fi
-
-    local lfname=""
-    generate_local_filename lfname
-    "${XDDTEST_XDD_EXE}" -op write -target "${lfname}" -reqsize 1 -blocksize "$((1024*1024))" -bytes "${size}" -datapattern random >/dev/null 2>&1
-
-    # Ensure the file size is correct
-    # shellcheck disable=SC2086
-    asize="$(${XDDTEST_XDD_GETFILESIZE_EXE} ${lfname})"
-    if [[ "${asize}" != "${size}" ]]; then
-        echo "Unable to generate test file data of size: ${size}"
-        finalize_test 2
-    fi
-
-    # Ensure the file isn't all zeros
-    read -r -n 4 < /dev/zero
-    local data="${REPLY}"
-    read -r -n 4 < "${lfname}"
-    if [[ "${REPLY}" = "${data}" ]]; then
-        echo "Unable to generate random test file data"
-        finalize_test 2
-    fi
-    eval "${varname}=${lfname}"
-    return 0
-}
-
-#
 # Remove any generated test data
 #
 cleanup_test_data() {


### PR DESCRIPTION
Call from source directory without configuring (`contrib/CI/shellcheck.sh <path>`)
Call from build directory (`make shellcheck`)

Closes #28

Also removed `generate_local_file` from `tests/common.sh` because it is never used