### PR TITLE
Modified tests to no longer use relative pathing

### DIFF
--- a/tests/debug/test_xdd_debug_init.sh
+++ b/tests/debug/test_xdd_debug_init.sh
@@ -7,10 +7,13 @@
 # Description - Just writes out to /dev/null using XDD with -debug INIT and verifies
 #               that the NUMA cpus are listed if requested through the debug flag
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 initialize_test
 

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(FUNCTIONAL
+    test_xdd_createnewfiles.sh
     test_xdd_createnewfiles2.sh
     test_xdd_dryrun.sh
     test_xdd_heartbeat_byte.sh

--- a/tests/functional/test_xdd_createnewfiles.sh
+++ b/tests/functional/test_xdd_createnewfiles.sh
@@ -5,11 +5,14 @@
 # Validate the output results of -createnewfiles on 1GB files
 #
 # Description - creates target file for each pass in an XDD run
-#
+
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 
 # Create the test location

--- a/tests/functional/test_xdd_createnewfiles2.sh
+++ b/tests/functional/test_xdd_createnewfiles2.sh
@@ -6,11 +6,14 @@
 # enabled
 #
 # Description - creates target file on unaligned files with dio enabled for each pass in an XDD run
-#
+
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 initialize_test
 data_file="${XDDTEST_LOCAL_MOUNT}/${TESTNAME}/test"

--- a/tests/functional/test_xdd_dryrun.sh
+++ b/tests/functional/test_xdd_dryrun.sh
@@ -6,10 +6,13 @@
 #
 # Description - passes the dry run option to a simple xdd command 
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Perform pre-test
 initialize_test
@@ -24,7 +27,7 @@ data_file="${test_dir}/test"
 
 # now run dryrun
 sleep_seconds=2
-"${XDDTEST_XDD_EXE}" -op read  -reqsize 1 -targets 1 "${data_file}" -dryrun &
+"${XDDTEST_XDD_EXE}" -op read  -reqsize 1 -numreqs 1 -targets 1 "${data_file}" -dryrun &
 pid=$!
 
 # sleep for 2 seconds before checking if XDD process is still running

--- a/tests/functional/test_xdd_heartbeat_byte.sh
+++ b/tests/functional/test_xdd_heartbeat_byte.sh
@@ -4,10 +4,13 @@
 #
 # Verify -hb byte, kbyte, mbyte, gbyte by checking if heartbeat output bytes equals actual transfered bytes and if output bytes matches output kbytes, mbytes, and gbytes
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Pre-test set-up
 

--- a/tests/functional/test_xdd_heartbeat_elapsed.sh
+++ b/tests/functional/test_xdd_heartbeat_elapsed.sh
@@ -5,8 +5,13 @@
 # Description: outputs the elapsed time since the start of run
 # Verify heartbeat elapsed time options works
 #
-source ../test_config
-source ../common.sh
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
+# Source the test configuration environment
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Pre-test set-up
 initialize_test

--- a/tests/functional/test_xdd_heartbeat_lf.sh
+++ b/tests/functional/test_xdd_heartbeat_lf.sh
@@ -4,10 +4,13 @@
 #
 # Verifty -hb lf by checking if output is printed with new lines
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # pre-test set-up
 initialize_test

--- a/tests/functional/test_xdd_heartbeat_output.sh
+++ b/tests/functional/test_xdd_heartbeat_output.sh
@@ -4,9 +4,13 @@
 #
 # Verify -hb output by checking if specified file exists
 #
-# Source test environment
-source ../test_config
-source ../common.sh
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
+# Source the test configuration environment
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Pre-test set-up
 initialize_test

--- a/tests/functional/test_xdd_heartbeat_target.sh
+++ b/tests/functional/test_xdd_heartbeat_target.sh
@@ -4,9 +4,13 @@
 #
 # Verify -tgt by checking if target number displayed matches target number tested
 #
-# Source test environment
-source ../test_config
-source ../common.sh
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
+# Source the test configuration environment
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # pre-test set-up
 initialize_test

--- a/tests/functional/test_xdd_heartbeat_tod.sh
+++ b/tests/functional/test_xdd_heartbeat_tod.sh
@@ -4,9 +4,13 @@
 #
 # Validate -hb tod by comparing it to current time
 #
-# Source test configuration environment
-source ../test_config
-source ../common.sh
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
+# Source the test configuration environment
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # pre-test set-up
 initialize_test

--- a/tests/functional/test_xdd_lockstep1.sh
+++ b/tests/functional/test_xdd_lockstep1.sh
@@ -5,10 +5,13 @@
 # Description - Do the simplest lockstep command possible
 #
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Create the test location
 initialize_test

--- a/tests/functional/test_xdd_lockstep2.sh
+++ b/tests/functional/test_xdd_lockstep2.sh
@@ -5,10 +5,13 @@
 # Description - Do the simplest lockstep command possible
 #
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Create the test location
 initialize_test

--- a/tests/functional/test_xdd_passdelay.sh
+++ b/tests/functional/test_xdd_passdelay.sh
@@ -7,10 +7,13 @@
 # Validate -passdelay by checking if the run time is greater
 #	 or equal to n-1 seconds times the amount of passes
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Pre-test set-up
 initialize_test

--- a/tests/functional/test_xdd_pretruncate.sh
+++ b/tests/functional/test_xdd_pretruncate.sh
@@ -7,10 +7,13 @@
 # Validate -pretruncate by checking if the test file size is equal to the
 #  truncation size
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Pre-test create test directory and file
 initialize_test

--- a/tests/functional/test_xdd_reopen.sh
+++ b/tests/functional/test_xdd_reopen.sh
@@ -6,10 +6,13 @@
 #
 # Verify -reopen by checking if (number of opens and closes during a pass + 1) equals number of opens and closes during the next incremented pass
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # pre-test set-up
 initialize_test

--- a/tests/functional/test_xdd_runtime.sh
+++ b/tests/functional/test_xdd_runtime.sh
@@ -6,10 +6,13 @@
 #
 # Description - terminates XDD after a given amount of seconds have passed
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Perform pre-test
 initialize_test

--- a/tests/functional/test_xdd_startdelay.sh
+++ b/tests/functional/test_xdd_startdelay.sh
@@ -5,10 +5,13 @@
 # Description - waits n amount of seconds before starting each pass
 # Validate -startdelay by checking if run time is greater or equal to n seconds times the amount of passes
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Pre-test set-up
 initialize_test

--- a/tests/functional/test_xdd_startoffset.sh
+++ b/tests/functional/test_xdd_startoffset.sh
@@ -6,9 +6,13 @@
 #
 # Validate -startoffset by comparing the size of a file starting from block 0 to its size starting from the nth block
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Pre-test set-up
 initialize_test

--- a/tests/functional/test_xdd_syncwrite.sh
+++ b/tests/functional/test_xdd_syncwrite.sh
@@ -4,10 +4,13 @@
 #
 # Test -syncwrite by checking if number of passes equals the number of fdatasyncs
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 #skip test on non-Linux platforms
 if [[ "$(uname)" != "Linux" ]]; then

--- a/tests/functional/test_xdd_timelimit.sh
+++ b/tests/functional/test_xdd_timelimit.sh
@@ -6,10 +6,13 @@
 #
 # Description - sets a time limit in seconds for each pass
 #
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
 # Source the test configuration environment
-#
-source ../test_config
-source ../common.sh
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
 
 # Perform pre-test
 initialize_test


### PR DESCRIPTION
Modified the way tests source the config and common.sh files, they are
now able to be called from anywhere as absolute pathing is now used.

Also added the test_xdd_createnewfiles.sh test to the list of tests to
run, as it was not being ran before.

Fixed an issue with test_xdd_dryrun that caused it not to be working
properly.

Closes #29.