### PR TITLE
Updating how we file datapatterns work

### DIFF
--- a/src/base/target_cleanup.c
+++ b/src/base/target_cleanup.c
@@ -69,7 +69,6 @@ xdd_target_thread_cleanup(target_data_t *tdp) {
             /* If the file target opend a file for the data pattern we must close
             * the files and clean up the data_pattern buffer
             */
-            close(tdp->dpp_fd);
             free(tdp->td_dpp->data_pattern);
         }
         free(tdp->td_dpp);

--- a/src/common/xint_prototypes.h
+++ b/src/common/xint_prototypes.h
@@ -35,7 +35,9 @@ int32_t	xdd_barrier(struct xdd_barrier *bp, xdd_occupant_t *occupantp, char owne
 // datapatterns.c
 void	xdd_datapattern_buffer_init(worker_data_t *wdp);
 void	xdd_datapattern_fill(worker_data_t *wdp);
-int		xdd_datapattern_wholefile_enough_ram(target_data_t *tdp);
+int	xdd_datapattern_wholefile_enough_ram(target_data_t *tdp, const char *filename);
+int	xdd_set_datapattern_from_filename(target_data_t *tdp, char *filename);
+int	xdd_set_datapattern_from_file_descriptor(target_data_t *tdp, int fd, char *filename);
 unsigned char *xdd_datapattern_get_datap_from_offset(worker_data_t *wdp);
 
 // debug.c

--- a/src/common/xint_td.h
+++ b/src/common/xint_td.h
@@ -156,7 +156,6 @@ struct xint_target_data {
 	struct xint_e2e				*td_e2ep;			// Pointer to the e2e struct when needed
 	struct xint_extended_stats	*td_esp;			// Extended Stats Structure Pointer
 	struct xint_triggers		*td_trigp;			// Triggers Structure Pointer
-	int                         dpp_fd;             // File descriptor for file data pattern
 	struct xint_data_pattern	*td_dpp;			// Data Pattern Structure Pointer
 	struct xint_raw				*td_rawp;          	// RAW Data Structure Pointer
 	struct lockstep				*td_lsp;			// Pointer to the lockstep structure used by the lockstep option

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -2,6 +2,7 @@ set(FUNCTIONAL
     test_xdd_createnewfiles.sh
     test_xdd_createnewfiles2.sh
     test_xdd_dryrun.sh
+    test_xdd_file_datapattern.sh
     test_xdd_heartbeat_byte.sh
     test_xdd_heartbeat_elapsed.sh
     test_xdd_heartbeat_lf.sh

--- a/tests/functional/test_xdd_file_datapattern.sh
+++ b/tests/functional/test_xdd_file_datapattern.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Acceptance test for XDD.
+#
+# Validate the funtionality of -datapattern file/wholefile option by creating a file, setting the datapattern
+# from that file and then verifying the contents match
+#
+# Description - terminates XDD after a given amount of seconds have passed
+#
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
+# Source the test configuration environment
+source "${SCRIPTPATH}"/../test_config
+source "${SCRIPTPATH}"/../common.sh 
+
+# Perform pre-test
+initialize_test
+test_dir="${XDDTEST_LOCAL_MOUNT}/${TESTNAME}"
+log_file="$(get_log_file)"
+
+input_file="${test_dir}/data1.dat"
+output_file="${test_dir}/data2.dat"
+
+# Create datapattern input file using dd
+dd if=/dev/urandom of="${input_file}" bs=4k count=2
+
+# Write out file using xdd with -datapattern file
+"${XDDTEST_XDD_EXE}" -op write -reqsize 8 -numreqs 1 -datapattern file "${input_file}" -targets 1 "${output_file}" -qd 1 -passes 1
+# Verify the contents of the file match
+if ! cmp "${input_file}" "${output_file}"
+then
+    echo "Error when comparing files ${input_file} and ${output_file} with -datapattern file" > "${log_file}"
+    cmp "${input_file}" "${output_file}" >> "${log_file}"
+    rm "${input_file}" "${output_file}"
+    finalize_test 1 "Issue with setting datapattern from file with -datapattern file. Contents don't match."
+fi
+
+rm "${output_file}"
+# Write out file using xdd with -datapattern wholefile
+# In this caes we will use two threads to write out the data in serial ordering as the
+# contents of the file will be distributed evenly between both threads.
+"${XDDTEST_XDD_EXE}" -op write -reqsize 4 -numreqs 2 -datapattern wholefile "${input_file}" -targets 1 "${output_file}" -serialordering -qd 2 -passes 1
+# Verify the contents of the file match
+if ! cmp "${input_file}" "${output_file}"
+then
+    echo "Error when comparing files ${input_file} and ${output_file} with -datapattern wholefile" > "${log_file}"
+    cmp "${input_file}" "${output_file}" >> "${log_file}"
+    rm "${input_file}" "${output_file}"
+    finalize_test 1 "Issue with setting datapattern from file with -datapattern file. Contents don't match."
+fi
+rm "${input_file}" "${output_file}"
+
+# Test passed
+finalize_test 0


### PR DESCRIPTION
Previously when the option -datapattern file/wholefile was used, XDD would open the file for every target and keep it open till the run was over. This is really unnecessary as the file only needs to be opened to read the datapattern in to set the datapattern in the target. Once that has happen, the file can immediately be closed. This is a good idea as there are limits to how many files can be opened in Linux (ulimit). XDD should not tie up the number of avialable open file descriptors just to set a datapattern over an entire XDD run.

The code has been updated to open the file, set the target data_pattern buffer, and then immediately close the file. I have added a new functional test case test_xdd_file_datapattern.sh to test out that these this modification did not break the expected functionality of -datapattern file/wholefile.