### PR TITLE
Introduce macro for error handling in target_data.c

### DIFF
--- a/src/client/parse_func.c
+++ b/src/client/parse_func.c
@@ -3509,7 +3509,10 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 		args_index += args;  /* skip past the "target <taget number>" */
 	}
 	/* At this point "args_index" is an index to the seek "option" argument */
-	if (strcmp(argv[args_index], "save") == 0) { /* save the seek information in a file */
+	if (argv[args_index] == NULL) {
+		fprintf(stderr, "%s: ERROR: No seek option specified. Please give a valid seek option.\n", xgp->progname);
+		return(-1);
+	} else if (strncmp(argv[args_index], "save", 5) == 0) { /* save the seek information in a file */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3528,7 +3531,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+2);
-	} else if (strcmp(argv[args_index], "load") == 0) { /* load seek list from "filename" */
+	} else if (strncmp(argv[args_index], "load", 5) == 0) { /* load seek list from "filename" */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3547,7 +3550,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+2);
-	} else if (strcmp(argv[args_index], "disthist") == 0) { /*  Print a Distance Histogram */
+	} else if (strncmp(argv[args_index], "disthist", 9) == 0) { /*  Print a Distance Histogram */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3566,7 +3569,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+2);
-	} else if (strcmp(argv[args_index], "seekhist") == 0) { /* Print a Seek Histogram */
+	} else if (strncmp(argv[args_index], "seekhist", 9) == 0) { /* Print a Seek Histogram */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3585,7 +3588,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+2);
-	} else if (strcmp(argv[args_index], "sequential") == 0) { /*  Sequential seek list option */
+	} else if (strncmp(argv[args_index], "sequential", 11) == 0) { /*  Sequential seek list option */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3604,7 +3607,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+1);
-	} else if (strcmp(argv[args_index], "random") == 0) { /*  Random seek list option */
+	} else if (strncmp(argv[args_index], "random", 7) == 0) { /*  Random seek list option */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3623,7 +3626,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+1);
-	} else if (strcmp(argv[args_index], "stagger") == 0) { /*  Staggered seek list option */
+	} else if (strncmp(argv[args_index], "stagger", 8) == 0) { /*  Staggered seek list option */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3644,7 +3647,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+2);
-	} else if (strcmp(argv[args_index], "interleave") == 0) { /* set the interleave for sequential seek locations */
+	} else if (strncmp(argv[args_index], "interleave", 11) == 0) { /* set the interleave for sequential seek locations */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3663,7 +3666,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+2);
-	} else if (strcmp(argv[args_index], "none") == 0) { /* no seeking at all */
+	} else if (strncmp(argv[args_index], "none", 5) == 0) { /* no seeking at all */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3682,7 +3685,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+1);
-	} else if (strcmp(argv[args_index], "range") == 0) { /* set the range of seek locations */
+	} else if (strncmp(argv[args_index], "range", 6) == 0) { /* set the range of seek locations */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);
@@ -3699,7 +3702,7 @@ xddfunc_seek(xdd_plan_t *planp, int32_t argc, char *argv[], uint32_t flags)
 			}
 		}
 		return(args_index+2);
-	} else if (strcmp(argv[args_index], "seed") == 0) { /* set the seed for random seek locations */
+	} else if (strncmp(argv[args_index], "seed", 5) == 0) { /* set the seed for random seek locations */
 		if (target_number >= 0) {  /* set option for specific target */
 			tdp = xdd_get_target_datap(planp, target_number, argv[0]);
 			if (tdp == NULL) return(-1);

--- a/src/client/parse_table.c
+++ b/src/client/parse_table.c
@@ -23,7 +23,7 @@
 //            struct xdd_func {
 //	              char    *func_name;     /* name of the function */
 //	              char    *func_alt;      /* Alternate name of the function */
-//                int     (*func_ptr)(int32_t argc, char *argv[], uint32_t flags, uint32_t flags);      /* pointer to the function */
+//                int     (*func_ptr)(int32_t argc, char *argv[], uint32_t flags);      /* pointer to the function */
 //                int     argc;           /* number of arguments */
 //                char    *help;          /* help string */
 //                char    *ext_help[5];   /* Extented help strings */

--- a/src/common/access_pattern.c
+++ b/src/common/access_pattern.c
@@ -198,6 +198,8 @@ xdd_init_seek_list(target_data_t *tdp) {
                                 (rw_op_index * ((tdp->td_reqsize*sp->seek_interleave) + gap));
 			/* end of generating a sequential seek */
 			
+			/* Now lets fill in the block sizes to transfer */
+			sp->seeks[rw_index].blocksize = tdp->td_block_size;
 			/* Now lets fill in the request sizes to transfer */
 			sp->seeks[rw_index].reqsize = tdp->td_reqsize;
 			/* Now lets fill in the appropriate operation */
@@ -350,11 +352,15 @@ xdd_save_seek_list(target_data_t *tdp) {
 		}
 		average = (uint64_t)(total / sp->seek_total_ops);
 		/* Print the seek list into the specified file */
+		fprintf(tmp, "# Block size=%d, Request size=%d, Numreqs=%ld\n",
+                (int32_t)tdp->td_block_size,
+                (int32_t)tdp->td_reqsize,
+                (long int)tdp->td_numreqs);
 		fprintf(tmp,"# Longest seek=%llu, Shortest seek=%llu, Average seek distance=%llu\n",
 			(unsigned long long)longest, 
 			(unsigned long long)shortest, 
 			(unsigned long long)average);
-		fprintf(tmp,"#Ordinal Location Reqsize Operation Time1 Time2\n"); 
+		fprintf(tmp,"#Ordinal Location Blocksize Reqsize Operation Time1 Time2\n"); 
 		for (i = 0; i < sp->seek_total_ops; i++) {
 			if (sp->seeks[i].operation == SO_OP_READ) 
 				opc = "r";
@@ -366,17 +372,19 @@ xdd_save_seek_list(target_data_t *tdp) {
 				opc = "u";
 			
 			if (tdp->td_seekhdr.seek_options & SO_SEEK_NONE) {
-				fprintf(tmp,"%010d %012llu %d %s %016llu %016llu\n",
+				fprintf(tmp,"%010d %012llu %d %d %s %016llu %016llu\n",
 					i,
 					(unsigned long long)sp->seeks[0].block_location, 
+					sp->seeks[0].blocksize, 
 					sp->seeks[0].reqsize, 
 					opc, 
 					(unsigned long long)(sp->seeks[i].time1),
 					(unsigned long long)(sp->seeks[i].time2));
 			} else {
-				fprintf(tmp,"%010d %012llu %d %s %016llu %016llu\n",
+				fprintf(tmp,"%010d %012llu %d %d %s %016llu %016llu\n",
 					i,
 					(unsigned long long)sp->seeks[i].block_location, 
+					sp->seeks[i].blocksize, 
 					sp->seeks[i].reqsize, 
 					opc, 
 					(unsigned long long)(sp->seeks[i].time1),
@@ -463,13 +471,14 @@ xdd_load_seek_list(target_data_t *tdp) {
 	char 		*tp;  		/* token pointer */
 	int32_t 	ordinal; 	/* ordinal number of the seek */
 	uint64_t 	loc;  		/* location */
+	int32_t     blocksz;    /* Block Size */
 	int32_t 	reqsz; 		// Request Size
 	nclk_t		t1,t2; 		/* time1 and time2 */
 	int32_t 	reqsz_high; 	/* highest request size*/
 	char 		rw;  		/* read or write operation */
 	char 		*status; 	/* status of the fgets */
 	struct seekhdr	*sp;
-	char 		line[1024]; 	/* one line of characters */
+	char 		line[LINE_LENGTH]; 	/* one line of characters */
 
 
 	sp = &tdp->td_seekhdr;
@@ -484,7 +493,7 @@ xdd_load_seek_list(target_data_t *tdp) {
 	status = line;
 	i = 0;
 	reqsz_high = 0;
-	while (status != NULL) {
+	while (status != NULL && i < tdp->td_numreqs) {
 		status = fgets(line, sizeof(line), loadfp);
 		if (status == NULL ) continue;
 		tp = line;
@@ -493,19 +502,25 @@ xdd_load_seek_list(target_data_t *tdp) {
 		/* Check for comment line */
 		if (*tp == COMMENT) continue;
 		/* Must be a seek line */
-		sscanf(line,"%d %llu %d %c %llu %llu", 
+		if (sscanf(line,"%d %llu %d %d %c %llu %llu", 
 			&ordinal,
 			(unsigned long long *)(&loc),
+			&blocksz,
 			&reqsz,
 			&rw,
 			(unsigned long long *)(&t1),
-			(unsigned long long *)(&t2));
+			(unsigned long long *)(&t2)) != 7) {
+				fprintf(xgp->errout, "%s: Error: Cannot parse seek load file %s\n",
+						xgp->progname, sp->seek_loadfile);
+				return(-1);
+		}
 		sp->seeks[i].block_location = loc;
 		if ((rw == 'w') || (rw == 'W')) 
 			sp->seeks[i].operation = SO_OP_WRITE;
 		else if ((rw == 'n') || (rw == 'N')) 
 			sp->seeks[i].operation = SO_OP_NOOP; /* NOOP */
 		else sp->seeks[i].operation = SO_OP_READ; /* READ */
+		sp->seeks[i].blocksize = blocksz;
 		sp->seeks[i].reqsize = reqsz;
 		sp->seeks[i].time1 = t1;
 		sp->seeks[i].time2 = t2;
@@ -513,6 +528,8 @@ xdd_load_seek_list(target_data_t *tdp) {
 		i++;
 	}
 	sp->seek_iosize = reqsz_high * tdp->td_block_size;
+	/* close the load file */
+	fclose(loadfp);
 	return(0);
 } /* end of xdd_load_seek_list() */
 

--- a/src/common/access_pattern.h
+++ b/src/common/access_pattern.h
@@ -20,7 +20,8 @@
 /** A single seek entry */
 struct seek_entries {
 	int32_t operation; /**< read or write */
-	int32_t reqsize; /**< Size of data transfer in blocks */
+	int32_t blocksize; /**< Size of data transfer in blocks */
+	int32_t reqsize; /**< Number of blocks in the request */
 	uint64_t block_location; /**< Starting location in blocks */
 	nclk_t time1;  /**< Relative time in nano seconds that this operation should start */
 	nclk_t time2;  /**< not yet implemented */

--- a/src/common/target_data.c
+++ b/src/common/target_data.c
@@ -15,7 +15,12 @@
  * with respect to the Target_Data and the Target_Data substructure.
  */
 #include "xint.h"
-
+#define PRINT_ERROR_AND_RETURN(pattern, filename) \
+	do { \
+		fprintf(xgp->errout, "%s: ERROR: Cannont parse %s from the first line of %s\n", \
+				xgp->progname, pattern, filename); \
+		return(-1); \
+	} while (0)
 
 /*----------------------------------------------------------------------------*/
 /* xdd_init_new_target_data() - Initialize the default Per-Target-Data-Structure
@@ -135,13 +140,11 @@ xdd_parse_value_from_line(char *line, const char *pattern, void *location, size_
 
 	if (size == sizeof(int32_t)) {
 		if (sscanf(line_str, "%*[^=]=%d", (int32_t *)location) != 1) {
-			fprintf(xgp->errout, "%s: ERROR: Cannot parse %s from the first line of %s\n",
-					xgp->progname, pattern, filename);
+			PRINT_ERROR_AND_RETURN(pattern, filename);
 		}
 	} else if (size == sizeof(int64_t)) {
 		if (sscanf(line_str, "%*[^=]=%ld", (int64_t *)location) != 1) {
-			fprintf(xgp->errout, "%s: ERROR: Cannot parse %s from the first line of %s\n",
-					xgp->progname, pattern, filename);
+			PRINT_ERROR_AND_RETURN(pattern, filename);
 		}
 	}
 

--- a/src/common/xint_common.h
+++ b/src/common/xint_common.h
@@ -34,6 +34,7 @@
 #define MAX_TARGETS 8192
 #define MAX_TARGET_NAME_LENGTH 2048
 #define MAXSEM 1
+#define LINE_LENGTH 1024
 
 /* program defines */
 #define COMMENT '#'

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -9,6 +9,7 @@ set(FUNCTIONAL
     test_xdd_heartbeat_output.sh
     test_xdd_heartbeat_target.sh
     test_xdd_heartbeat_tod.sh
+    test_xdd_load_file.sh
     test_xdd_lockstep1.sh
     test_xdd_lockstep2.sh
     test_xdd_pretruncate.sh

--- a/tests/functional/test_xdd_load_file.sh
+++ b/tests/functional/test_xdd_load_file.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Description - test xdd seek load
+#
+# Validate that xdd seek load is able to load a file with or without
+# numreqs. It should also overwrite the blocksize and reqsize if provided.
+#
+# Get absolute path to script
+SCRIPT=${BASH_SOURCE[0]}
+SCRIPTPATH=$(dirname "${SCRIPT}")
+
+# Source the test configuration environment
+source "${SCRIPTPATH}/../test_config"
+source "${SCRIPTPATH}/../common.sh"
+
+# Perform pre-test
+initialize_test
+test_dir="${XDDTEST_LOCAL_MOUNT}/${TESTNAME}"
+
+# Function to load a file with optional numreqs, blocksize, and reqsize
+seek_load_file() {
+  local load_file=$1
+  local numreqs=$2
+  local blocksize=$3
+  local reqsize=$4
+  local params=""
+
+  # If the optional parameters are provided, add them to the command
+  if [[ -n "${numreqs}" ]]; then
+    params+=" -numreqs ${numreqs}"
+  fi
+  if [[ -n "${blocksize}" ]]; then
+    params+=" -blocksize ${blocksize}"
+  fi
+  if [[ -n "${reqsize}" ]]; then
+    params+=" -reqsize ${reqsize}"
+  fi
+
+  # Execute the command
+  "${XDDTEST_XDD_EXE}" -seek load "${load_file}" -target /dev/null "${params}"
+}
+
+# Function to verify the output
+verify_output() {
+  local output=$1
+  local expected_numreqs=$2
+  local expected_blocksize=$3
+  local expected_reqsize=$4
+
+  # Extract the numreqs, blocksize, and reqsize from the output
+  local numreqs
+  numreqs=$(echo "${output}" | grep -oP 'Number of Operations, \K[0-9]+')
+  local blocksize
+  blocksize=$(echo "${output}" | grep -oP 'Blocksize in bytes, \K[0-9]+')
+  local reqsize
+  reqsize=$(echo "${output}" | grep -oP 'Request size, [0-9]+, 1024-byte blocks, \K[0-9]+')
+
+  # Verify the numreqs, blocksize, and reqsize with the expected values
+  if [[ "${numreqs}" != "${expected_numreqs}" ]]; then
+    echo "Numreqs verification failed: expected ${expected_numreqs}, got ${numreqs}"
+    return 1
+  fi
+
+  if [[ "${blocksize}" != "${expected_blocksize}" ]]; then
+    echo "Blocksize verification failed: expected ${expected_blocksize}, got ${blocksize}"
+    return 1
+  fi
+
+  if [[ "${reqsize}" != "${expected_reqsize}" ]]; then
+    echo "Reqsize verification failed: expected ${expected_reqsize}, got ${reqsize}"
+    return 1
+  fi
+}
+
+# Test 1: Default blocksize and reqsize with numreqs 10
+seek_file="${test_dir}/fool.dat"
+load_file="${seek_file}.T0.txt"
+
+# Create a file with numreqs 10 using default blocksize and reqsize
+"${XDDTEST_XDD_EXE}" -seek save "${seek_file}" -target /dev/null -numreqs 10
+
+# Test cases for default blocksize and reqsize
+# 1. Load the file with
+#    no numreqs, no blocksize, and no reqsize
+output=$(seek_load_file "${load_file}")
+verify_output "${output}" 10 1024 131072
+
+# 2. Load the file with
+#       numreqs < seek file lines, no blocksize, and reqsize
+output=$(seek_load_file "${load_file}" 5 "" 128)
+verify_output "${output}" 5 1024 131072
+
+# 3. Load the file with
+#    no numreqs, blocksize, and no reqsize
+output=$(seek_load_file "${load_file}" "" 4096 "")
+verify_output "${output}" 10 1024 131072
+
+# 4. Load the file with
+#       numreq > seek file lines, no blocksize, and no reqsize
+output=$(seek_load_file "${load_file}" 20 "" "")
+verify_output "${output}" 10 1024 131072
+
+# Clean up
+rm -f "${seek_file}" "${load_file}"
+
+# Test 2: blocksize 8192 and reqsize 256 with numreqs 5
+# Create a file with numreqs 5, custom blocksize, and custom reqsize
+"${XDDTEST_XDD_EXE}" -seek save "${seek_file}" -target /dev/null -numreqs 5 -blocksize 8192 -reqsize 256
+verify_output "${output}" 5 8192 256
+
+# Test cases for custom blocksize and reqsize
+# 1. Load the file with
+#    no numreqs, no blocksize, and no reqsize
+output=$(seek_load_file "${load_file}")
+verify_output "${output}" 5 8192 256
+
+# 2. Load the file with 
+#       numreqs, no blocksize, and reqsize < seek file reqsize
+output=$(seek_load_file "${load_file}" 3 "" 128)
+verify_output "${output}" 3 8192 256
+
+# 3. Load the file with
+#    no numreqs,    blocksize, and no reqsize
+output=$(seek_load_file "${load_file}" "" 4096 "")
+verify_output "${output}" 5 8192 256
+
+# 4. Load the file with
+#      numreqs > seek file lines, no blocksize, and no reqsize
+output=$(seek_load_file "${load_file}" 10 "" "")
+verify_output "${output}" 10 8192 256
+
+# Clean up
+rm -f "${seek_file}" "${load_file}"
+
+# Output test result
+finalize_test 0


### PR DESCRIPTION
This commit refactors the error handling mechanism by introducing a new macro, PRINT_ERROR_AND_RETURN in target_data.c. mentioned [here](https://github.com/MigeljanImeri/xdd/pull/40#discussion_r1824917923).